### PR TITLE
added default header value

### DIFF
--- a/gotrue/client.py
+++ b/gotrue/client.py
@@ -11,7 +11,7 @@ import uuid
 from typing import Any, Callable, Dict, Optional
 
 from gotrue.api import GoTrueApi
-from gotrue.lib.constants import GOTRUE_URL, STORAGE_KEY
+from gotrue.lib.constants import GOTRUE_URL, STORAGE_KEY, DEFAULT_HEADERS
 
 
 HTTPRegexp = "/^http://"
@@ -51,13 +51,15 @@ class Client:
                 "Warning:\n\nDO NOT USE HTTP IN PRODUCTION FOR GOTRUE EVER!\n"
                 "GoTrue REQUIRES HTTPS to work securely."
             )
+        self.headers = DEFAULT_HEADERS
+        self.headers.update(headers)
         self.state_change_emitters: Dict[str, Any] = {}
         self.current_user = None
         self.current_session = None
         self.auto_refresh_token = auto_refresh_token
         self.persist_session = persist_session
         self.local_storage: Dict[str, Any] = {}
-        self.api = GoTrueApi(url=url, headers=headers, cookie_options=cookie_options)
+        self.api = GoTrueApi(url=url, headers=self.headers, cookie_options=cookie_options)
         self._recover_session()
 
     def sign_up(self, email: str, password: str):

--- a/gotrue/lib/constants.py
+++ b/gotrue/lib/constants.py
@@ -1,12 +1,16 @@
+from gotrue import __version__
+
 GOTRUE_URL = 'http://localhost:9999'
 AUDIENCE = ''
-DEFAULT_HEADERS = {}
+DEFAULT_HEADERS = {
+    "X-Client-Info": f"gotrue-py/{__version__}"
+}
 EXPIRY_MARGIN = 60 * 1000
 STORAGE_KEY = 'supabase.auth.token'
 COOKIE_OPTIONS = {
-        "name": 'sb:token',
-        "lifetime": 60 * 60 * 8,
-        "domain": '',
-        "path": '/',
-        "sameSite": 'lax',
-        }
+    "name": 'sb:token',
+    "lifetime": 60 * 60 * 8,
+    "domain": '',
+    "path": '/',
+    "sameSite": 'lax',
+}

--- a/tests/test_gotrue.py
+++ b/tests/test_gotrue.py
@@ -114,3 +114,15 @@ def test_set_auth(client: Client):
     client.set_auth(mock_access_token)
     new_session = client.session()
     assert new_session["access_token"] == mock_access_token
+
+
+def test_default_headers(client: Client):
+    """Test client for existing default headers"""
+    from gotrue import __version__
+    default_key = "X-Client-Info"
+    client_info = f"gotrue-py/{__version__}"
+    assert default_key in client.headers
+    assert client.headers[default_key] == client_info
+
+    assert default_key in client.api.headers
+    assert client.api.headers[default_key] == client_info


### PR DESCRIPTION
added DEFAULT_HEADERS to Client class and passing composed headers dict to GoTrueApi class.

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Default headers constant exists

## What is the new behavior?

Default header constant is filled with version and passed into Client class

Related to [Issue](https://github.com/supabase/gotrue-py/issues/10)