### PR TITLE
Inherit from Exception

### DIFF
--- a/gotrue/exceptions.py
+++ b/gotrue/exceptions.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 
 @dataclass
-class APIError(BaseException):
+class APIError(Exception):
     msg: str
     code: int
 


### PR DESCRIPTION
Inherit from Exception instead of from BaseException.
More info: [https://docs.python.org/3/tutorial/errors.html#tut-userexceptions](https://docs.python.org/3/tutorial/errors.html#tut-userexceptions)

Thanks for the report: @ktosiek