### PR TITLE
fix: string formatting in `delete_user`

### DIFF
--- a/gotrue/_async/api.py
+++ b/gotrue/_async/api.py
@@ -553,7 +553,7 @@ class AsyncGoTrueAPI:
             If an error occurs
         """
         headers = self._create_request_headers(jwt=jwt)
-        url = f"{self.url}/admin/users/${uid}"
+        url = f"{self.url}/admin/users/{uid}"
         response = await self.http_client.delete(url, headers=headers)
         return User.parse_response(response)
 

--- a/gotrue/_sync/api.py
+++ b/gotrue/_sync/api.py
@@ -553,7 +553,7 @@ class SyncGoTrueAPI:
             If an error occurs
         """
         headers = self._create_request_headers(jwt=jwt)
-        url = f"{self.url}/admin/users/${uid}"
+        url = f"{self.url}/admin/users/{uid}"
         response = self.http_client.delete(url, headers=headers)
         return User.parse_response(response)
 


### PR DESCRIPTION
The delete user method is not working.

This seems to be due to a leftover from javascript style string formatting (dollar sign).

Proposed edits.

These seem to work in the case of my local development environment.