### PR TITLE
fix: parse_auth_response to handle cases when data is an empty dictio…

### DIFF
--- a/gotrue/helpers.py
+++ b/gotrue/helpers.py
@@ -28,7 +28,8 @@ def parse_auth_response(data: Any) -> AuthResponse:
         and data["expires_in"]
     ):
         session = Session.parse_obj(data)
-    user = User.parse_obj(data["user"]) if "user" in data else None
+    user_data = data.get("user", data)
+    user = User.parse_obj(user_data) if user_data else None
     return AuthResponse(session=session, user=user)
 
 

--- a/gotrue/helpers.py
+++ b/gotrue/helpers.py
@@ -28,7 +28,7 @@ def parse_auth_response(data: Any) -> AuthResponse:
         and data["expires_in"]
     ):
         session = Session.parse_obj(data)
-    user = User.parse_obj(data["user"]) if "user" in data else User.parse_obj(data)
+    user = User.parse_obj(data["user"]) if "user" in data else None
     return AuthResponse(session=session, user=user)
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, the `parse_auth_response()` function in `helpers.py` throws a validation error when it's argument `data` is an empty dictionary `{}`.

<img width="1122" alt="image" src="https://user-images.githubusercontent.com/56215649/232412298-6c4db75a-d371-4d0c-a7e5-080772d69259.png">


## What is the new behavior?

In the new commit, `parse_auth_response()` function returns an `AuthResponse(user=None, session=None)` response when it's argument `data` is an empty dictionary `{}`.

<img width="1112" alt="supabase-py" src="https://user-images.githubusercontent.com/56215649/232413291-e5f12e7a-8352-4370-b055-33fbf461cd8f.png">

## Additional context

[#231](https://github.com/supabase-community/gotrue-py/issues/231)

## Help

Hi @J0! I'm having trouble setting up the environment for the repository. If I could get some assistance on this, I'll write the necessary changes to pass the test checks.