### PR TITLE
optional last_sign_in_at in UserIdentity type

### DIFF
--- a/gotrue/types.py
+++ b/gotrue/types.py
@@ -120,7 +120,7 @@ class UserIdentity(BaseModel):
     identity_data: Dict[str, Any]
     provider: str
     created_at: datetime
-    last_sign_in_at: datetime
+    last_sign_in_at: Union[datetime, None] = None
     updated_at: Union[datetime, None] = None
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`supabase.auth.get_user` raises 
```
gotrue.errors.AuthRetryableError: 1 validation error for UserResponse
user -> identities -> 0 -> last_sign_in_at
  field required (type=value_error.missing)
```
when the user hasn't signed in before
