### PR TITLE
fix: fix semantic release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,16 @@ jobs:
         run: |
           pip install pydantic==1.10.12
           make tests_only
-
   publish:
     needs: test
     if: ${{ !startsWith(github.event.head_commit.message, 'bump') && !startsWith(github.event.head_commit.message, 'chore') && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository_owner == 'supabase-community' }}
     runs-on: ubuntu-latest
     name: "Bump version, create changelog and publish"
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gotrue
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: Clone Repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,21 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
+          # This action uses Python Semantic Release v8
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@master
+        id: release
+        uses: python-semantic-release/python-semantic-release@v8.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          repository_username: __token__
-          repository_password: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
+        # See https://github.com/actions/runner/issues/1173
+        if: steps.release.outputs.released == 'true'
+
+      - name: Publish package distributions to GitHub Releases
+        uses: python-semantic-release/upload-to-gh-release@main
+        if: steps.release.outputs.released == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/gotrue/types.py
+++ b/gotrue/types.py
@@ -25,9 +25,11 @@ Provider = Literal[
     "bitbucket",
     "discord",
     "facebook",
+    "figma",
     "github",
     "gitlab",
     "google",
+    "kakao",
     "keycloak",
     "linkedin",
     "notion",
@@ -36,6 +38,7 @@ Provider = Literal[
     "twitch",
     "twitter",
     "workos",
+    "zoom"
 ]
 
 AuthChangeEventMFA = Literal["MFA_CHALLENGE_VERIFIED"]

--- a/gotrue/types.py
+++ b/gotrue/types.py
@@ -38,7 +38,7 @@ Provider = Literal[
     "twitch",
     "twitter",
     "workos",
-    "zoom"
+    "zoom",
 ]
 
 AuthChangeEventMFA = Literal["MFA_CHALLENGE_VERIFIED"]


### PR DESCRIPTION
## What kind of change does this PR introduce?
-  With version 7, Semantic release [no longer supports the use of PyPI Token, username and password](https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#removal-of-pypi-token-repository-username-and-repository-password-inputs) We should instead go through the official PyPA action and trusted publisher. The trusted publisher has been configured.
- Separately contains a change which Addresses #292 by adding the types for the new providers.  Let me know if it's preferred that we split this into a separate PR

