### PR TITLE
fix: update version options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pygithub = "^1.57"
 
 [tool.semantic_release]
 version_variable = "gotrue/__init__.py:__version__"
-version_toml = "pyproject.toml:tool.poetry.version"
+version_toml = ["pyproject.toml:tool.poetry.version"]
 major_on_zero = false
 commit_subject = "chore(release): bump version to v{version}"
 build_command = "curl -sSL https://install.python-poetry.org | python - && export PATH=\"/github/home/.local/bin:$PATH\" && poetry install && poetry build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ version_toml = ["pyproject.toml:tool.poetry.version"]
 major_on_zero = false
 commit_subject = "chore(release): bump version to v{version}"
 build_command = "curl -sSL https://install.python-poetry.org | python - && export PATH=\"/github/home/.local/bin:$PATH\" && poetry install && poetry build"
-upload_to_repository = true
+upload_to_vcs_release = true
 branch = "main"
 changelog_components = "semantic_release.changelog.changelog_headers,semantic_release.changelog.compare_url"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Looks like the [version.toml](https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#version-toml) needs to be updated too