### PR TITLE
feat: support pagination for auth admin list_users

### DIFF
--- a/gotrue/_async/gotrue_admin_api.py
+++ b/gotrue/_async/gotrue_admin_api.py
@@ -100,7 +100,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
             xform=parse_user_response,
         )
 
-    async def list_users(self) -> List[User]:
+    async def list_users(self, page: int = None, per_page: int = None) -> List[User]:
         """
         Get a list of users.
 
@@ -110,6 +110,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         return await self._request(
             "GET",
             "admin/users",
+            query={"page": page, "per_page": per_page},
             xform=lambda data: [model_validate(User, user) for user in data["users"]]
             if "users" in data
             else [],

--- a/gotrue/_sync/gotrue_admin_api.py
+++ b/gotrue/_sync/gotrue_admin_api.py
@@ -100,7 +100,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
             xform=parse_user_response,
         )
 
-    def list_users(self) -> List[User]:
+    def list_users(self, page: int = None, per_page: int = None) -> List[User]:
         """
         Get a list of users.
 
@@ -110,6 +110,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         return self._request(
             "GET",
             "admin/users",
+            query={"page": page, "per_page": per_page},
             xform=lambda data: [model_validate(User, user) for user in data["users"]]
             if "users" in data
             else [],


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

The auth admin `list_users` function will only return the 50 most recent users without the option to fetch more per page or move to another page

## What is the new behavior?

Now, the auth admin `list_users` function accepts both `page` and `per_page` named parameters to enable pagination.

## Additional context

None
