### PR TITLE
fix: add verify token hash

### DIFF
--- a/gotrue/types.py
+++ b/gotrue/types.py
@@ -42,12 +42,7 @@ Provider = Literal[
 ]
 
 EmailOtpType = Literal[
-    "signup",
-    "invite",
-    "magiclink",
-    "recovery",
-    "email_change",
-    "email"
+    "signup", "invite", "magiclink", "recovery", "email_change", "email"
 ]
 
 AuthChangeEventMFA = Literal["MFA_CHALLENGE_VERIFIED"]
@@ -347,15 +342,15 @@ class VerifyMobileOtpParams(TypedDict):
     ]
     options: NotRequired[VerifyOtpParamsOptions]
 
+
 class VerifyTokenHashParams(TypedDict):
     token_hash: str
     type: EmailOtpType
     options: NotRequired[VerifyOtpParamsOptions]
 
+
 VerifyOtpParams = Union[
-    VerifyEmailOtpParams,
-    VerifyMobileOtpParams,
-    VerifyTokenHashParams
+    VerifyEmailOtpParams, VerifyMobileOtpParams, VerifyTokenHashParams
 ]
 
 

--- a/gotrue/types.py
+++ b/gotrue/types.py
@@ -41,6 +41,15 @@ Provider = Literal[
     "zoom",
 ]
 
+EmailOtpType = Literal[
+    "signup",
+    "invite",
+    "magiclink",
+    "recovery",
+    "email_change",
+    "email"
+]
+
 AuthChangeEventMFA = Literal["MFA_CHALLENGE_VERIFIED"]
 
 AuthChangeEvent = Literal[
@@ -325,13 +334,7 @@ class VerifyOtpParamsOptions(TypedDict):
 class VerifyEmailOtpParams(TypedDict):
     email: str
     token: str
-    type: Literal[
-        "signup",
-        "invite",
-        "magiclink",
-        "recovery",
-        "email_change",
-    ]
+    type: EmailOtpType
     options: NotRequired[VerifyOtpParamsOptions]
 
 
@@ -344,10 +347,15 @@ class VerifyMobileOtpParams(TypedDict):
     ]
     options: NotRequired[VerifyOtpParamsOptions]
 
+class VerifyTokenHashParams(TypedDict):
+    token_hash: str
+    type: EmailOtpType
+    options: NotRequired[VerifyOtpParamsOptions]
 
 VerifyOtpParams = Union[
     VerifyEmailOtpParams,
     VerifyMobileOtpParams,
+    VerifyTokenHashParams
 ]
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Allows passing a `token_hash` and `type` in `verify_otp` method 
* Supports this change on gotrue: https://github.com/supabase/gotrue/pull/1165

This is the equivalent of https://github.com/supabase/gotrue-js/pull/722 to make it easier to do fully server-side when double confirm is turned on for email confirmation.