### PR TITLE
Use urlsafe_b64decode to properly handle URL-encoded JWTs

### DIFF
--- a/gotrue/helpers.py
+++ b/gotrue/helpers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from base64 import b64decode
+from base64 import urlsafe_b64decode
 from json import loads
 from typing import Any, Dict, Type, TypeVar, Union, cast
 
@@ -123,4 +123,4 @@ def decode_jwt_payload(token: str) -> Any:
     # Addding padding otherwise the following error happens:
     # binascii.Error: Incorrect padding
     base64UrlWithPadding = base64Url + "=" * (-len(base64Url) % 4)
-    return loads(b64decode(base64UrlWithPadding).decode("utf-8"))
+    return loads(urlsafe_b64decode(base64UrlWithPadding).decode("utf-8"))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When set_session() is called with a base64URL encoded JWT (instead of normal base64 encoding), it fails. Giving it a normally encoded JWT also fails, because the request later uses the access_token as passed here and it requires base64URL encoding.

## What is the new behavior?

By using urlsafe_b64decode, base64URL encoded JWTs now work properly

## Additional context

none
