### PR TITLE
bug fix: use pydantic v2 model.model_rebuild

### DIFF
--- a/gotrue/types.py
+++ b/gotrue/types.py
@@ -673,7 +673,7 @@ for model in [
 ]:
     try:
         # pydantic > 2
-        model.rebuild_model()
+        model.model_rebuild()
     except AttributeError:
         # pydantic < 2
         model.update_forward_refs()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When I run tests I see the following warnings:

```
(venv) ... % pytest src/tests/integration/test_abc.py       
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.9.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/...
configfile: pytest.ini
plugins: anyio-4.1.0
collected 7 items                                                                                                                                                                                          

src/tests/integration/test_abc.py .......                                                                                                                                                    [100%]

============================================================================================= warnings summary =============================================================================================
venv/lib/python3.9/site-packages/gotrue/types.py:679: 19 warnings
  /Users/.../venv/lib/python3.9/site-packages/gotrue/types.py:679: PydanticDeprecatedSince20: The `update_forward_refs` method is deprecated; use `model_rebuild` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.3/migration/
    model.update_forward_refs()

venv/lib/python3.9/site-packages/pydantic/main.py:1206: 19 warnings
  /Users/.../venv/lib/python3.9/site-packages/pydantic/main.py:1206: PydanticDeprecatedSince20: The `update_forward_refs` method is deprecated; use `model_rebuild` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.3/migration/
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================================== 7 passed, 38 warnings in 1.77s ======================================================================================
```

## What is the new behavior?

No warning messages are seen

## Additional context

None
