### PR TITLE
fix: remove unnecessary async to on_auth_state_change

### DIFF
--- a/gotrue/_async/gotrue_client.py
+++ b/gotrue/_async/gotrue_client.py
@@ -500,7 +500,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         await self._remove_session()
         self._notify_all_subscribers("SIGNED_OUT", None)
 
-    async def on_auth_state_change(
+    def on_auth_state_change(
         self,
         callback: Callable[[AuthChangeEvent, Union[Session, None]], None],
     ) -> Subscription:


### PR DESCRIPTION
## What kind of change does this PR introduce?

It fixes on_auth_state_change not be async. Somehow it got reverted on a refactor (https://github.com/supabase-community/gotrue-py/commit/e7ebc64112d970673265c7b314a1e8820fc0f7e1)

## What is the current behavior?

It was async.

## What is the new behavior?

It's not async anymore.

## Additional context

This causes problems when using the supabase client, since it's not being awaited: https://github.com/supabase-community/supabase-py/blob/main/supabase/_async/client.py#L90
