### PR TITLE
feat: add sign_out() scope option

### DIFF
--- a/gotrue/_async/gotrue_admin_api.py
+++ b/gotrue/_async/gotrue_admin_api.py
@@ -14,6 +14,7 @@ from ..types import (
     GenerateLinkParams,
     GenerateLinkResponse,
     Options,
+    SignOutScope,
     User,
     UserResponse,
 )
@@ -39,13 +40,13 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         self.mfa.list_factors = self._list_factors
         self.mfa.delete_factor = self._delete_factor
 
-    async def sign_out(self, jwt: str) -> None:
+    async def sign_out(self, jwt: str, scope: SignOutScope = "global") -> None:
         """
         Removes a logged-in session.
         """
         return await self._request(
             "POST",
-            "logout",
+            f"logout?scope={scope}",
             jwt=jwt,
             no_resolve_json=True,
         )

--- a/gotrue/_async/gotrue_admin_api.py
+++ b/gotrue/_async/gotrue_admin_api.py
@@ -46,7 +46,8 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         """
         return await self._request(
             "POST",
-            f"logout?scope={scope}",
+            "logout",
+            query={"scope": scope},
             jwt=jwt,
             no_resolve_json=True,
         )

--- a/gotrue/_async/gotrue_client.py
+++ b/gotrue/_async/gotrue_client.py
@@ -60,6 +60,7 @@ from ..types import (
     SignInWithOAuthCredentials,
     SignInWithPasswordCredentials,
     SignInWithPasswordlessCredentials,
+    SignOutOptions,
     SignUpWithPasswordCredentials,
     Subscription,
     UserAttributes,
@@ -480,7 +481,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         session = await self._call_refresh_token(refresh_token)
         return AuthResponse(session=session, user=session.user)
 
-    async def sign_out(self) -> None:
+    async def sign_out(self, options: SignOutOptions = {"scope": "global"}) -> None:
         """
         Inside a browser context, `sign_out` will remove the logged in user from the
         browser session and log them out - removing all items from localstorage and
@@ -496,10 +497,11 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
             session = await self.get_session()
             access_token = session.access_token if session else None
             if access_token:
-                await self.admin.sign_out(access_token)
+                await self.admin.sign_out(access_token, options["scope"])
 
-        await self._remove_session()
-        self._notify_all_subscribers("SIGNED_OUT", None)
+            if options["scope"] != "others":
+                await self._remove_session()
+                self._notify_all_subscribers("SIGNED_OUT", None)
 
     def on_auth_state_change(
         self,

--- a/gotrue/_sync/gotrue_admin_api.py
+++ b/gotrue/_sync/gotrue_admin_api.py
@@ -14,6 +14,7 @@ from ..types import (
     GenerateLinkParams,
     GenerateLinkResponse,
     Options,
+    SignOutScope,
     User,
     UserResponse,
 )
@@ -39,13 +40,13 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         self.mfa.list_factors = self._list_factors
         self.mfa.delete_factor = self._delete_factor
 
-    def sign_out(self, jwt: str) -> None:
+    def sign_out(self, jwt: str, scope: SignOutScope = "global") -> None:
         """
         Removes a logged-in session.
         """
         return self._request(
             "POST",
-            "logout",
+            f"logout?scope={scope}",
             jwt=jwt,
             no_resolve_json=True,
         )

--- a/gotrue/_sync/gotrue_admin_api.py
+++ b/gotrue/_sync/gotrue_admin_api.py
@@ -46,7 +46,8 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
         """
         return self._request(
             "POST",
-            f"logout?scope={scope}",
+            "logout",
+            query={"scope": scope},
             jwt=jwt,
             no_resolve_json=True,
         )

--- a/gotrue/_sync/gotrue_client.py
+++ b/gotrue/_sync/gotrue_client.py
@@ -60,6 +60,7 @@ from ..types import (
     SignInWithOAuthCredentials,
     SignInWithPasswordCredentials,
     SignInWithPasswordlessCredentials,
+    SignOutOptions,
     SignUpWithPasswordCredentials,
     Subscription,
     UserAttributes,
@@ -478,7 +479,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         session = self._call_refresh_token(refresh_token)
         return AuthResponse(session=session, user=session.user)
 
-    def sign_out(self) -> None:
+    def sign_out(self, options: SignOutOptions = {"scope": "global"}) -> None:
         """
         Inside a browser context, `sign_out` will remove the logged in user from the
         browser session and log them out - removing all items from localstorage and
@@ -494,10 +495,11 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
             session = self.get_session()
             access_token = session.access_token if session else None
             if access_token:
-                self.admin.sign_out(access_token)
+                self.admin.sign_out(access_token, options["scope"])
 
-        self._remove_session()
-        self._notify_all_subscribers("SIGNED_OUT", None)
+            if options["scope"] != "others":
+                self._remove_session()
+                self._notify_all_subscribers("SIGNED_OUT", None)
 
     def on_auth_state_change(
         self,

--- a/gotrue/types.py
+++ b/gotrue/types.py
@@ -650,6 +650,13 @@ class DecodedJWTDict(TypedDict):
     amr: NotRequired[Union[List[AMREntry], None]]
 
 
+SignOutScope = Literal["global", "local", "others"]
+
+
+class SignOutOptions(TypedDict):
+    scope: NotRequired[SignOutScope]
+
+
 for model in [
     AMREntry,
     AuthResponse,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the scope option to the `sign_out` method which can be used to control which sessions should be signed out of the account.

Closes #371 

## What is the current behavior?

Only supports global scope

## What is the new behavior?

Supports `global`, `local` and `others` scope.

## Additional context

https://github.com/supabase/gotrue/pull/1112
https://github.com/supabase/gotrue-js/pull/713
